### PR TITLE
Simplify Makefile and invocation from mix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,3 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 libusb-*.tar
-*.so
-
-*libusb-1.0.*
-.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -1,85 +1,89 @@
-ifeq ($(ERL_EI_INCLUDE_DIR),)
-ERL_ROOT_DIR = $(shell erl -eval "io:format(\"~s~n\", [code:root_dir()])" -s init stop -noshell)
-ifeq ($(ERL_ROOT_DIR),)
-   $(error Could not find the Erlang installation. Check to see that 'erl' is in your PATH)
-endif
-ERL_EI_INCLUDE_DIR = "$(ERL_ROOT_DIR)/usr/include"
-ERL_EI_LIBDIR = "$(ERL_ROOT_DIR)/usr/lib"
+# Makefile for building the NIF
+#
+# Makefile targets:
+#
+# all           build and install the NIF
+# mix_clean     clean build products and intermediates
+#
+# Variables to override:
+#
+# MIX_APP_PATH  path to the build directory
+#
+# CC            C compiler
+# CROSSCOMPILE	crosscompiler prefix, if any
+# CFLAGS	compiler flags for compiling all C files
+# ERL_CFLAGS	additional compiler flags for files using Erlang header files
+# ERL_EI_INCLUDE_DIR include path to ei.h (Required for crosscompile)
+# ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
+# LDFLAGS	linker flags for linking all binaries
+# ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
+
+LIBUSB_VERSION := 1.0.22
+
+PREFIX = $(MIX_APP_PATH)/priv
+BUILD  = $(MIX_APP_PATH)/obj
+
+LIBUSB_NIF := $(PREFIX)/libusb_nif.so
+
+LIBUSB_SRC_DIR = $(MIX_APP_PATH)/libusb-$(LIBUSB_VERSION)
+LIBUSB_BUILD_DIR = $(MIX_APP_PATH)/libusb
+LIBUSB_INCLUDE_DIR = $(LIBUSB_BUILD_DIR)/include
+LIBUSB_LIBDIR = $(LIBUSB_BUILD_DIR)/lib
+LIBUSB_LIB = $(LIBUSB_LIBDIR)/libusb-1.0.a
+
+LIBUSB_CFLAGS = -I$(LIBUSB_INCLUDE_DIR)
+LIBUSB_LDFLAGS = -L$(LIBUSB_LIBDIR) -lusb-1.0
+LIBUSB_NIF_SRC = c_src/libusb_nif.c
+
+NIF_CFLAGS = -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
+NIF_LDFLAGS = -fPIC -shared -pedantic
+
+ifeq ($(CROSSCOMPILE),)
+    # Not crosscompiling
+    ifeq ($(shell uname),Darwin)
+        NIF_LDFLAGS += -undefined dynamic_lookup
+    endif
+else
+    # Crosscompiled build
+    # NOTE: Use REBAR_TARGET_ARCH out of convenience.
+    CONFIGURE_OPTS = --target=$(REBAR_TARGET_ARCH) --host=$(REBAR_TARGET_ARCH) --disable-udev
 endif
 
 # Set Erlang-specific compile and linker flags
 ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
 ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
-# NIF_CFLAGS := -O2 -flat_namespace -undefined suppress
-# NIF_LDFLAGS := -fPIC -shared -pedantic
-# BUILD_DIR := $(PWD)/_build
+LIBUSB_TAR_BZ2 := libusb-$(LIBUSB_VERSION).tar.bz2
+LIBUSB_DL_URL := "https://iweb.dl.sourceforge.net/project/libusb/libusb-1.0/libusb-$(LIBUSB_VERSION)/$(LIBUSB_TAR_BZ2)"
+LIBUSB_DL := $(MIX_APP_PATH)/$(LIBUSB_TAR_BZ2)
 
-PRIV_DIR := priv
-LIBUSB_NIF := $(PRIV_DIR)/libusb_nif.so
+calling_from_make:
+	mix compile
 
-.PHONY: all clean dir-clean
+all: $(PREFIX) $(BUILD) $(LIBUSB_SRC_DIR) $(LIBUSB_NIF)
 
-# MIX_BUILD_PATH := $(PWD)/_build
-LIBUSB_VERSION := 1.0.22
-LIBUSB_SRC_DIR := $(MIX_BUILD_PATH)/libusb-$(LIBUSB_VERSION)
-LIBUSB_BUILD_DIR := $(MIX_BUILD_PATH)/libusb
-LIBUSB_INCLUDE_DIR := $(LIBUSB_BUILD_DIR)/include
-LIBUSB_LIBDIR := $(LIBUSB_BUILD_DIR)/lib
-LIBUSB_LIB := $(LIBUSB_LIBDIR)/libusb-1.0.so
+$(LIBUSB_DL):
+	cd $(MIX_APP_PATH) && wget $(LIBUSB_DL_URL)
 
-PRIV_DIR := priv
-LIBUSB_CFLAGS := -I$(LIBUSB_INCLUDE_DIR)
-LIBUSB_LDFLAGS := -L$(LIBUSB_LIBDIR) -lusb-1.0
-LIBUSB_NIF_SRC := c_src/libusb_nif.c
-
-NIF_CFLAGS := -O2
-NIF_LDFLAGS := -fPIC -shared -pedantic
-NIF_CFLAGS ?= -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
-
-ifeq ($(CROSSCOMPILE),)
-ifeq ($(shell uname),Darwin)
-NIF_LDFLAGS += -undefined dynamic_lookup
-endif
-endif
-
-LIBUSB_DL := libusb-$(LIBUSB_VERSION).tar.bz2
-LIBUSB_DL_URL := "https://iweb.dl.sourceforge.net/project/libusb/libusb-1.0/libusb-$(LIBUSB_VERSION)/$(LIBUSB_DL)"
-
-.PHONY: all clean libusb-clean dir-clean
-
-all: $(PRIV_DIR) $(LIBUSB_SRC_DIR) $(LIBUSB_NIF)
-
-$(LIBUSB_SRC_DIR):
-	cd $(MIX_BUILD_PATH) && wget $(LIBUSB_DL_URL) && tar xf $(LIBUSB_DL)
-
-$(PRIV_DIR):
-	mkdir -p $(PRIV_DIR)
-
-# $(LIBUSB_NIF): c_src/libusb_nif.c
-# 	echo haai
-# 	$(CC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS) -o $@ $<
+$(LIBUSB_SRC_DIR): $(LIBUSB_DL)
+	cd $(MIX_APP_PATH) && tar xf $(LIBUSB_DL)
 
 $(LIBUSB_NIF): $(LIBUSB_LIB) $(LIBUSB_NIF_SRC) Makefile
 	$(CC) -o $@ $(LIBUSB_NIF_SRC) \
-	$(LIBUSB_CFLAGS) $(ERL_CFLAGS) $(NIF_CFLAGS) \
-	$(ERL_LDFLAGS) $(NIF_LDFLAGS) $(LIBUSB_LDFLAGS)
-
-$(LIBUSB_BUILD_DIR):
-	mkdir -p $(LIBUSB_BUILD_DIR)
+	  $(CFLAGS) $(LIBUSB_CFLAGS) $(ERL_CFLAGS) $(NIF_CFLAGS) \
+	  $(LDFLAGS) $(ERL_LDFLAGS) $(NIF_LDFLAGS) $(LIBUSB_LDFLAGS)
 
 $(LIBUSB_SRC_DIR)/config.status: $(LIBUSB_BUILD_DIR)
-	cd $(LIBUSB_SRC_DIR) && ./configure --prefix=$(LIBUSB_BUILD_DIR) --host=$(MAKE_HOST) --build=$(BUILD) --disable-udev
+	cd $(LIBUSB_SRC_DIR) && ./configure --prefix=$(LIBUSB_BUILD_DIR) $(CONFIGURE_OPTS)
 
 $(LIBUSB_LIB): $(LIBUSB_SRC_DIR)/config.status
-	cd $(LIBUSB_SRC_DIR) && make && make install
+	$(MAKE) -C $(LIBUSB_SRC_DIR) all install
 
-clean:
+$(PREFIX) $(BUILD) $(LIBUSB_BUILD_DIR):
+	mkdir -p $@
+
+mix_clean:
 	$(RM) $(LIBUSB_NIF)
-	$(RM) c_src/*.o
+	$(MAKE) -C $(LIBUSB_SRC_DIR) clean
 
-libusb-clean:
-	cd $(LIBUSB_SRC_DIR) && make clean
-
-dir-clean: clean libusb-clean
-	$(RM) $(LIBUSB_NOF)
+.PHONY: all mix_clean

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule LibUsb.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       compilers: [:elixir_make] ++ Mix.compilers(),
-      make_clean: ["clean"],
-      make_env: make_env(),
+      make_clean: ["mix_clean"],
+      make_targets: ["all"],
       package: package(),
       description: description(),
       start_permanent: Mix.env() == :prod,
@@ -16,19 +16,6 @@ defmodule LibUsb.MixProject do
       aliases: [format: [&format_c/1, "format"]]
       # dialyzer: [plt_add_apps: [:iex]]
     ]
-  end
-
-  defp make_env() do
-    case System.get_env("ERL_EI_INCLUDE_DIR") do
-      nil ->
-        %{
-          "ERL_EI_INCLUDE_DIR" => "#{:code.root_dir()}/usr/include",
-          "ERL_EI_LIBDIR" => "#{:code.root_dir()}/usr/lib"
-        }
-
-      _ ->
-        %{}
-    end
   end
 
   # Run "mix help compile.app" to learn about applications.
@@ -41,7 +28,7 @@ defmodule LibUsb.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:elixir_make, "~> 0.5", runtime: false},
+      {:elixir_make, "~> 0.6.2", runtime: false},
       {:dialyxir, "~> 0.5.1", only: :dev, runtime: false},
       {:ex_doc, "~> 0.18.1", only: [:dev, :test]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.5.2", "96a28c79f5b8d34879cd95ebc04d2a0d678cfbbd3e74c43cb63a76adf0ee8054", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm", "c57508ddad47dfb8038ca6de1e616e66e9b87313220ac5d9817bc4a4dc2257b9"},
+  "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "33d7b70d87d45ed899180fb0413fb77c7c48843188516e15747e00fdecf572b6"},
 }


### PR DESCRIPTION
This updates elixir_make to pull in environment variables for locating
the build directory and makes the corresponding simplifications to the
Makefile. It also simplifies the Make targets and some variables to make
future updates easier.



